### PR TITLE
Handle Skipped Tests

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -61,6 +61,7 @@
               </div>
             </div>
           </div>
+          {{if .Skipped}}
           <div class="column">
             <div class="card">
               <header class="card-header has-background-link-light">
@@ -71,6 +72,7 @@
               </div>
             </div>
           </div>
+          {{end}}
         </div>
         <!-- Testcases table -->
         {{if .TestCases}}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/michaelsatish/junit-xml-viewer
 
-go 1.18
+go 1.21

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type TestSuite struct {
 	Name      string     `xml:"name,attr"`
 	Errors    string     `xml:"errors,attr"`
 	Failures  string     `xml:"failures,attr"`
-	Skipped   string     `xml:"skipped,attr"`
+	Skipped   string     `xml:"skipped,attr,omitempty"`
 	Tests     string     `xml:"tests,attr"`
 	Time      string     `xml:"time,attr"`
 	Timestamp string     `xml:"timestamp,attr"`
@@ -57,8 +57,13 @@ func (ts *TestSuite) GetSuccessCount() int {
 	tests := intCov(ts.Tests)
 	failures := intCov(ts.Failures)
 	errors := intCov(ts.Errors)
-	skipped := intCov(ts.Skipped)
 
+	// Not all test suites have skipped tests.
+	if ts.Skipped == "" {
+		return tests - failures - errors
+	}
+
+	skipped := intCov(ts.Skipped)
 	return tests - failures - errors - skipped
 }
 
@@ -161,7 +166,7 @@ func main() {
 		log.Fatal("The JUnit XML file does not exist in the given path.")
 	}
 
-	data, err := ioutil.ReadFile(xmlPath)
+	data, err := os.ReadFile(xmlPath)
 	checkError(err)
 
 	// Unmarshal the xml file contents into a TestSuites struct.


### PR DESCRIPTION
Not all Junit XML reports have skipped attr, the changes will show the skipped only when it is available. 